### PR TITLE
Added v1 repository filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ The following environment variables can be set:
  * `USER_PROMPT` - Sets the default action for user prompts (non-error)
   * `true` - (_Default_) Prompts user for input/validation
   * `false` - Skips user prompt and automatically proceeds
- * `V1_REPO_FILTER` - Search filter to limit the scope of the images to migrate (uses [grep basic regular expression interpretation](http://www.gnu.org/software/grep/manual/html_node/Basic-vs-Extended.html))
+ * `V1_REPO_FILTER` - Search filter to limit the scope of the repositories to migrate (uses [grep basic regular expression interpretation](http://www.gnu.org/software/grep/manual/html_node/Basic-vs-Extended.html))
+  * *Note*: This only filters the repositories returned from the v1 search API, not the individual tags
  * `V1_USERNAME` - Username used for `docker login` to the v1 registry
  * `V1_PASSWORD` - Password used for `docker login` to the v1 registry
  * `V1_EMAIL` - Email used for `docker login` to the v1 registry

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The following environment variables can be set:
  * `USER_PROMPT` - Sets the default action for user prompts (non-error)
   * `true` - (_Default_) Prompts user for input/validation
   * `false` - Skips user prompt and automatically proceeds
+ * `V1_REPO_FILTER` - Search filter to limit the scope of the images to migrate (uses [grep basic regular expression interpretation](http://www.gnu.org/software/grep/manual/html_node/Basic-vs-Extended.html))
  * `V1_USERNAME` - Username used for `docker login` to the v1 registry
  * `V1_PASSWORD` - Password used for `docker login` to the v1 registry
  * `V1_EMAIL` - Email used for `docker login` to the v1 registry

--- a/migrator.sh
+++ b/migrator.sh
@@ -203,7 +203,15 @@ decode_auth() {
 # query the v1 registry for a list of all images
 query_v1_images() {
   echo -e "\n${INFO} Getting a list of images from ${V1_REGISTRY}"
-  IMAGE_LIST="$(curl -s https://${AUTH_CREDS}@${V1_REGISTRY}/v1/search?q= | jq -r '.results | .[] | .name')"
+  # check to see if a filter pattern was provided
+  if [ -z "${V1_REPO_FILTER}" ]
+  then
+    # no filter pattern was defined, get all repos
+    IMAGE_LIST="$(curl -s https://${AUTH_CREDS}@${V1_REGISTRY}/v1/search?q= | jq -r '.results | .[] | .name')"
+  else
+    # filter pattern defined, use grep to match repos w/regex capabilites
+    IMAGE_LIST="$(curl -s https://${AUTH_CREDS}@${V1_REGISTRY}/v1/search?q= | jq -r '.results | .[] | .name' | grep ${V1_REPO_FILTER})"
+  fi
 
   # loop through all images in v1 registry to get tags for each
   for i in ${IMAGE_LIST}


### PR DESCRIPTION
This adds a v1 repository filter (fixes #14) so that a migration can occur for a portion of the registry instead of only being able to perform a migration of the entire v1 registry.