### PR TITLE
setting NO_LOGIN will allow one to continue without logging in

### DIFF
--- a/migrator.sh
+++ b/migrator.sh
@@ -376,7 +376,7 @@ migration_complete() {
 main() {
   initialize_migrator
   verify_ready
-  if [[ "${NO_LOGIN}" != "true" ]]; then
+  if [ "${NO_LOGIN}" != "true" ]; then
     docker_login ${V1_REGISTRY} ${V1_USERNAME} ${V1_PASSWORD} ${V1_EMAIL}
   fi
   decode_auth ${V1_REGISTRY}
@@ -385,7 +385,7 @@ main() {
   pull_images_from_v1
   check_registry_swap_or_retag
   verify_v2_ready
-  if [[ "${NO_LOGIN}" != "true" ]]; then
+  if [ "${NO_LOGIN}" != "true" ]; then
     docker_login ${V2_REGISTRY} ${V2_USERNAME} ${V2_PASSWORD} ${V2_EMAIL}
   fi
   push_images_to_v2

--- a/migrator.sh
+++ b/migrator.sh
@@ -376,14 +376,18 @@ migration_complete() {
 main() {
   initialize_migrator
   verify_ready
-  docker_login ${V1_REGISTRY} ${V1_USERNAME} ${V1_PASSWORD} ${V1_EMAIL}
+  if [[ "${NO_LOGIN}" != "true" ]]; then
+    docker_login ${V1_REGISTRY} ${V1_USERNAME} ${V1_PASSWORD} ${V1_EMAIL}
+  fi
   decode_auth ${V1_REGISTRY}
   query_v1_images
   show_v1_image_list
   pull_images_from_v1
   check_registry_swap_or_retag
   verify_v2_ready
-  docker_login ${V2_REGISTRY} ${V2_USERNAME} ${V2_PASSWORD} ${V2_EMAIL}
+  if [[ "${NO_LOGIN}" != "true" ]]; then
+    docker_login ${V2_REGISTRY} ${V2_USERNAME} ${V2_PASSWORD} ${V2_EMAIL}
+  fi
   push_images_to_v2
   cleanup_local_engine
   migration_complete


### PR DESCRIPTION
When running migrator against my TLS-secure but unauthenticated v2 registry, I was getting stuck at a prompt to login to the v2 registry. Entering no username to log in to the v1 registry allowed the process to continue, but this was not working when it got to the v2 registry.

I added the NO_LOGIN env check to allow main() to skip attempts to login altogether.