### PR TITLE
V2 registry check - Only check the HTTP response status

### DIFF
--- a/migrator.sh
+++ b/migrator.sh
@@ -452,8 +452,8 @@ verify_v2_ready() {
   V2_READY="false"
   while [ "${V2_READY}" = "false" ]
   do
-    # check to see if V2_REGISTRY is returning the proper api version string
-    if $(curl ${V2_OPTIONS} -Is ${PROTO}://${V2_REGISTRY}/v2/ | grep ^'Docker-Distribution-Api-Version: registry/2' > /dev/null 2>&1)
+    # check to see if V2_REGISTRY is a V2 registry
+    if $(curl ${V2_OPTIONS} -Is ${PROTO}://${V2_REGISTRY}/v2/ > /dev/null 2>&1)
     then
       # api version indicates v2; sets value to exit loop
       V2_READY="true"


### PR DESCRIPTION
The [API documentation](https://docs.docker.com/registry/spec/api/#api-version-check) does not specify the response body for the version check request,
so do not make assumptions about it.

In my current tests, it actually returns an empty object, which fails the check.