### PR TITLE
Modified the docker/migrator tool to support AWS ECS registries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.2
+FROM alpine:3.3
 
 RUN (apk add --update bash curl jq wget groff less python py-pip &&\
   pip install awscli &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM alpine:3.3
 
-RUN (apk add --update bash curl jq wget groff less python py-pip &&\
+RUN apk --no-cache add bash curl jq wget groff less python py-pip &&\
   pip install awscli &&\
-  apk --purge -v del py-pip &&\
-  rm -rf /var/cache/apk/*)
+  apk --purge -v del py-pip
 
 ### use docker-1.6.2; upgrading will break password decryption
 RUN (wget "https://get.docker.com/builds/Linux/x86_64/docker-1.6.2" -O /usr/bin/docker &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM alpine:3.3
+FROM alpine:3.2
 
-RUN apk --no-cache add bash curl jq wget
+RUN (apk add --update bash curl jq wget groff less python py-pip &&\
+  pip install awscli &&\
+  apk --purge -v del py-pip &&\
+  rm -rf /var/cache/apk/*)
 
 ### use docker-1.6.2; upgrading will break password decryption
 RUN (wget "https://get.docker.com/builds/Linux/x86_64/docker-1.6.2" -O /usr/bin/docker &&\

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 docker/migrator
 =================
 
-Tool to migrate Docker images from Docker Hub or v1 registry to a v2 registry including AWS ECS Repositories
+Tool to migrate Docker images from Docker Hub or v1 registry to a v2 registry including Amazon EC2 Container Registry (ECR) 
 
-https://hub.docker.com/r/mattnowina/migrator/
+https://hub.docker.com/r/docker/migrator/
 
 ## Usage
 
 ```
-docker run --rm -it -v ~/.aws:/root/.aws:ro -v /var/run/docker.sock:/var/run/docker.sock -e V1_REGISTRY=v1.registry.fqdn -e V2_REGISTRY=v2.registry.fqdn mattnowina/migrator
-
-OR
-
-docker run -rm -it -v /var/run/docker.sock:/var/run/docker.sock -e AWS_ACCESS_KEY_ID=<key> -e AWS_SECRET_ACCESS_KEY=<secret> -e V1_REGISTRY=v1.registry.fqdn -e V2_REGISTRY=v2.registry.fqdn mattnowina/migrator
+docker run -it \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -e V1_REGISTRY=v1.registry.fqdn \
+    -e V2_REGISTRY=v2.registry.fqdn \
+    docker/migrator
 ```
 
 ### Environment Variables
@@ -82,6 +82,25 @@ This migration tool assumes the following:
   * The new v2 registry can either be running using a different DNS name or the same DNS name as the v1 registry - both scenarios work in this case.  If you are utilizing the same DNS name for your new v2 registry, set both `V1_REGISTRY` and `V2_REGISTRY` to the same value.
 
 It is suggested that you run this container on a Docker engine that is located near your registry as you will need to pull down every image from your v1 registry (or Docker Hub) and push them to the v2 registry to complete the migration.  This also means that you will need enough disk space on your local Docker engine to temporarily store all of the images.
+
+If you're interested in migrating to an Amazon EC2 Container Registry (ECR) you will additionally need to supply your AWS API keys to the migrator tool. This can be accomplished in one of the two following ways:
+
+```
+docker run -it \
+    -v ~/.aws:/root/.aws:ro \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -e V1_REGISTRY=v1.registry.fqdn \
+    -e V2_REGISTRY=v2.registry.fqdn \
+docker/migrator
+
+docker run -it \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -e AWS_ACCESS_KEY_ID=<key> \
+    -e AWS_SECRET_ACCESS_KEY=<secret> \
+    -e V1_REGISTRY=v1.registry.fqdn \
+    -e V2_REGISTRY=v2.registry.fqdn \
+docker/migrator
+```
 
 ## How Migration Works
 The migration occurs using an automated script inside of the Docker container.  Running using the above usage will work as expected.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 docker/migrator
 =================
 
-Tool to migrate Docker images from Docker Hub or v1 registry to a v2 registry
+Tool to migrate Docker images from Docker Hub or v1 registry to a v2 registry including AWS ECS Repositories
 
-https://hub.docker.com/r/docker/migrator/
+https://hub.docker.com/r/mattnowina/migrator/
 
 ## Usage
 
 ```
-docker run -it \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -e V1_REGISTRY=v1.registry.fqdn \
-  -e V2_REGISTRY=v2.registry.fqdn \
-  docker/migrator
+docker run --rm -it -v ~/.aws:/root/.aws:ro -v /var/run/docker.sock:/var/run/docker.sock -e V1_REGISTRY=v1.registry.fqdn -e V2_REGISTRY=v2.registry.fqdn mattnowina/migrator
+
+OR
+
+docker run -rm -it -v /var/run/docker.sock:/var/run/docker.sock -e AWS_ACCESS_KEY_ID=<key> -e AWS_SECRET_ACCESS_KEY=<secret> -e V1_REGISTRY=v1.registry.fqdn -e V2_REGISTRY=v2.registry.fqdn mattnowina/migrator
 ```
 
 ### Environment Variables
@@ -26,6 +26,8 @@ The following environment variables can be set:
 
 #### Optional
 
+  * `AWS_ACCESS_KEY` - AWS Access Key supplied as either an environment variable or as a part of your credentials file.
+  * `AWS_SECRET_ACCESS_KEY` - AWS Secret Access Key supplied as either an environment variable or as a part of your credentials file. 
   * `ERROR_ACTION` - Sets the default action on error for pushes and pulls
     * `prompt` - (_Default_) Prompt for user input as to what action to take on error
     * `retry` - Retry the failed action on error (may cause infinite loop of failure)


### PR DESCRIPTION
I modified the docker/migrator tool to add support for AWS Elastic Container Registry (ECR) as a destination. The modifications are made so that only if AWS credentials are passed into the container through a credential file or runtime environment variable will the ECR destination be used. This change is submitted for consideration and integration into the existing tool.