### PR TITLE
Do not migrate tags that exist at the target repository already

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ The following environment variables can be set:
   * `LIBRARY_NAMESPACE` - Sets option to migrate official namespaces (images where there is no namespace provided) to the `library/` namespace (Note: must be set to `true` for DTR 1.4 or greater)
     * `true` - (_Default_) Adds `library` namespace to image names
     * `false` - Keeps images as they are without a namespace
+  * `SKIP_EXISTING_TAGS` - Option to skip tags that exist at the target repository
+    * `true` - Do not migrate tags that exist at the target repository
+    * `false` - (_Default_) Do not skip any tags 
   * Custom CA certificate and Client certificate support - for custom CA and/or client certificate support to your v1 and/or v2 registries, you should utilize a volume to share them into the container by adding the following to your run command:
     * `-v /etc/docker/certs.d:/etc/docker/certs.d:ro`
   * `V1_USERNAME` - Username used for `docker login` to the v1 registry


### PR DESCRIPTION
We are migrating a very large repository, and while we migrate, new tags will be pushed. Also, we are not really switching over to the new repository at instant, but there will be a couple of days after beginning of migration up to when we change the DNS to target the v2 repository.

The current implementation would try to push all images again as soon as we start the second run, which doesn't really bother when it comes to pushing them again, but the images will be pulled down to the migration machine anyways, which consumes a lot of time.

To make this faster, I added a routine that will compare the list of tags at the target with the tags found at the source. If a tag is present at the target, it will not try to push it again.

Note: I was unable to test the part when migrating from the official docker.io hub which apparently works a bit different. A quick test if that works would be very much appreciated.