### PR TITLE
Refactor tag filtering

### DIFF
--- a/migrator.sh
+++ b/migrator.sh
@@ -488,10 +488,10 @@ filter_tags() {
     else
       # if tag filter, check for a match
       if [ "$j" == "${V1_TAG_FILTER}" ]; then
-        echo -e "${INFO} Skipping ${FULL_IMAGE_NAME}"
-      else
-        # didn't match, so add the tag
+        # Match, so add the tag
         FULL_IMAGE_LIST="${FULL_IMAGE_LIST} ${FULL_IMAGE_NAME}"
+      else
+        echo -e "${INFO} Skipping ${FULL_IMAGE_NAME}"
       fi
     fi
   fi

--- a/migrator.sh
+++ b/migrator.sh
@@ -461,6 +461,42 @@ json_array_contains() {
   fi
 }
 
+strip_library() {
+  # check if an image ($1) is a 'library' image without a namespace and LIBRARY_NAMESPACE is set to false
+  if [ "${1:0:8}" = "library/" ] && [ "${LIBRARY_NAMESPACE}" = "false" ]; then
+    # cut off 'library/' from beginning of image
+    echo "${1:8}"
+  else
+    echo $1
+  fi
+}
+
+# Filter tags if a specific tag was given, or they exist in the destination.
+filter_tags() {
+  # Only add path separator if namespace is set. Dockerhub added username,
+  # but it is not required by the V2 api.
+  FULL_IMAGE_NAME="${NAMESPACE}${NAMESPACE:+/}${i}:${j}"
+
+  # only append this tag to the list if the tag wasn't pushed before
+  if [ $(json_array_contains ${TAGS_AT_TARGET} ${j}) = "true" ]; then
+    echo -e "${INFO} Skipping ${FULL_IMAGE_NAME}"
+  else
+    # no tag filter
+    if [ -z "${V1_TAG_FILTER}" ]; then
+      # add each tag to list
+      FULL_IMAGE_LIST="${FULL_IMAGE_LIST} ${FULL_IMAGE_NAME}"
+    else
+      # if tag filter, check for a match
+      if [ "$j" == "${V1_TAG_FILTER}" ]; then
+        echo -e "${INFO} Skipping ${FULL_IMAGE_NAME}"
+      else
+        # didn't match, so add the tag
+        FULL_IMAGE_LIST="${FULL_IMAGE_LIST} ${FULL_IMAGE_NAME}"
+      fi
+    fi
+  fi
+}
+
 # query the source registry for a list of all images
 query_source_images() {
   echo -e "\n${INFO} Getting a list of images from ${V1_REGISTRY}"
@@ -511,7 +547,7 @@ query_source_images() {
       # set page URL to start with
       PAGE_URL="https://hub.docker.com/v2/repositories/${NAMESPACE}/?page=1&page_size=25"
 
-      # no filter pattern was defined, get all repos, looping through each page
+      # get all repos, filtering by V1_REPO_FILTER
       while [ "${PAGE_URL}" != "null" ]
       do
         # get a list of repos on this page
@@ -553,36 +589,8 @@ query_source_images() {
       # build a list of images from tags
       for j in ${IMAGE_TAGS}
       do
-        # check if an image is a 'library' image without a namespace and LIBRARY_NAMESPACE is set to false
-        if [ "${i:0:8}" = "library/" ] && [ "${LIBRARY_NAMESPACE}" = "false" ]
-        then
-          # cut off 'library/' from beginning of image
-          i="${i:8}"
-        fi
-          # check if tag filter was provided
-          if [ -z "${V1_TAG_FILTER}" ]
-          # no tag filter, add image and tag to list
-          then
-            # only append this tag to the list, if the tag wasn't pushed before
-            if [ $(json_array_contains ${TAGS_AT_TARGET} ${j}) = "true" ]; then
-              echo -e "${INFO} Skipping ${NAMESPACE}/${i}:${j}"
-            else
-              # add each tag to list
-              FULL_IMAGE_LIST="${FULL_IMAGE_LIST} ${NAMESPACE}/${i}:${j}"
-            fi
-          else
-	    # if tag filter, check for a match
-            if [ "$j" == "${V1_TAG_FILTER}" ]
-            then
-              # only append this tag to the list, if the tag wasn't pushed before
-              if [ $(json_array_contains ${TAGS_AT_TARGET} ${j}) = "true" ]; then
-                echo -e "${INFO} Skipping ${NAMESPACE}/${i}:${j}"
-              else
-                # add each tag to list
-                FULL_IMAGE_LIST="${FULL_IMAGE_LIST} ${NAMESPACE}/${i}:${j}"
-              fi
-            fi
-          fi
+        i=$(strip_library $i)
+        filter_tags
       done
     done
   else
@@ -605,23 +613,12 @@ query_source_images() {
       # retrieve a list of tags at the target repository
       TAGS_AT_TARGET=$(query_tags_to_skip ${i})
 
+
       # loop through tags to create list of full image names w/tags
       for j in ${IMAGE_TAGS}
       do
-        # check if an image is a 'library' image without a namespace and LIBRARY_NAMESPACE is set to false
-        if [ "${i:0:8}" = "library/" ] && [ "${LIBRARY_NAMESPACE}" = "false" ]
-        then
-          # cut off 'library/' from beginning of image
-          i="${i:8}"
-        fi
-
-        # only append this tag to the list, if the tag wasn't pushed before
-        if [ $(json_array_contains ${TAGS_AT_TARGET} ${j}) = "true" ]; then
-          echo -e "${INFO} Skipping $i:$j"
-        else
-          # add image to list
-          FULL_IMAGE_LIST="${FULL_IMAGE_LIST} ${i}:${j}"
-        fi
+        i=$(strip_library $i)
+        filter_tags
       done
     done
   fi


### PR DESCRIPTION
Tag filtering was missing for private repositories. Break tag filtering
out into a function and use it for both docker-hub and private repos.