### PR TITLE
Support ability to provide list of repos to migrate, Add ECR support to skip tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 docker/migrator
 =================
 
-Tool to migrate Docker images from Docker Hub or v1 registry to a v2 registry including Amazon EC2 Container Registry (ECR) 
+Tool to migrate Docker images from Docker Hub or v1 registry to a v2 registry including Amazon EC2 Container Registry (ECR)
 
 https://hub.docker.com/r/docker/migrator/
 
@@ -27,7 +27,7 @@ The following environment variables can be set:
 #### Optional
 
   * `AWS_ACCESS_KEY` - AWS Access Key supplied as either an environment variable or as a part of your credentials file.
-  * `AWS_REGION` - AWS Region, must be specified if using ECR 
+  * `AWS_REGION` - AWS Region, must be specified if using ECR
   * `AWS_SECRET_ACCESS_KEY` - AWS Secret Access Key supplied as either an environment variable or as a part of your credentials file.
   * `ERROR_ACTION` - Sets the default action on error for pushes and pulls
     * `prompt` - (_Default_) Prompt for user input as to what action to take on error
@@ -67,6 +67,8 @@ The following environment variables can be set:
     * `false` - (_Default_) Requires curl to connect to v2 registry over HTTPS
   * `DOCKER_HUB_ORG` - Docker Hub organization name to migrate images from
     * Defaults to the username used to login to Docker Hub if not provided
+  * `V1_FULL_REPO_LIST`
+    * If provided, this allows the user to provide a whitespace separated list of repos for migration. This allows skipping the _search step in case it is disabled
   * `V1_REPO_FILTER` - Search filter to limit the scope of the repositories to migrate (uses [grep basic regular expression interpretation](http://www.gnu.org/software/grep/manual/html_node/Basic-vs-Extended.html))
     * *Note*: This only filters the repositories returned from the source registry search API, not the individual tags
   * `V1_TAG_FILTER` - Search filter to limit the scope of the tags to migrate (Plain text matching).
@@ -75,7 +77,7 @@ The following environment variables can be set:
     * `false` - Keeps images as they are without a namespace
   * `SKIP_EXISTING_TAGS` - Option to skip tags that exist at the target repository
     * `true` - Do not migrate tags that exist at the target repository
-    * `false` - (_Default_) Do not skip any tags 
+    * `false` - (_Default_) Do not skip any tags
   * Custom CA certificate and Client certificate support - for custom CA and/or client certificate support to your v1 and/or v2 registries, you should utilize a volume to share them into the container by adding the following to your run command:
     * `-v /etc/docker/certs.d:/etc/docker/certs.d:ro`
   * `V1_USERNAME` - Username used for `docker login` to the v1 registry

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following environment variables can be set:
   * `DOCKER_HUB_ORG` - Docker Hub organization name to migrate images from
     * Defaults to the username used to login to Docker Hub if not provided
   * `V1_FULL_REPO_LIST`
-    * If provided, this allows the user to provide a whitespace separated list of repos for migration. This allows skipping the _search step in case it is disabled
+    * If provided, this allows the user to provide a whitespace separated list of repos for migration. This allows skipping the V1 call to `_search` (some setups might have search disabled)
   * `V1_REPO_FILTER` - Search filter to limit the scope of the repositories to migrate (uses [grep basic regular expression interpretation](http://www.gnu.org/software/grep/manual/html_node/Basic-vs-Extended.html))
     * *Note*: This only filters the repositories returned from the source registry search API, not the individual tags
   * `V1_TAG_FILTER` - Search filter to limit the scope of the tags to migrate (Plain text matching).

--- a/migrator.sh
+++ b/migrator.sh
@@ -627,11 +627,11 @@ query_source_images() {
     # Allow user to provide the full repo list
     if [ -z "${V1_FULL_REPO_LIST}" ]
     then
-      FULL_REPO_LIST=${V1_FULL_REPO_LIST}
-    else
       # get a list of all repos
       echo -e "${INFO} Grabbing list of repositories from ${V1_REGISTRY}"
       FULL_REPO_LIST=$(curl ${V1_OPTIONS} -sf ${V1_PROTO}://${AUTH_CREDS}@${V1_REGISTRY}/v1/search?q= | jq -r '.results | .[] | .name') || catch_error "curl => API failure"
+    else
+      FULL_REPO_LIST=${V1_FULL_REPO_LIST}
     fi
     # check to see if a filter pattern was provided
     if [ -z "${V1_REPO_FILTER}" ]

--- a/migrator.sh
+++ b/migrator.sh
@@ -160,7 +160,7 @@ verify_ready() {
       # AWS REGION must be specified if using ECR
       if [ -z "${AWS_REGION}" ]
       then
-  	catch_error "\$AWS_REGION required"
+  	    catch_error "\$AWS_REGION required"
       fi
 
       AWS_ECR="true"
@@ -630,6 +630,7 @@ query_source_images() {
       FULL_REPO_LIST=${V1_FULL_REPO_LIST}
     else
       # get a list of all repos
+      echo -e "${INFO} Grabbing list of repositories from ${V1_REGISTRY}"
       FULL_REPO_LIST=$(curl ${V1_OPTIONS} -sf ${V1_PROTO}://${AUTH_CREDS}@${V1_REGISTRY}/v1/search?q= | jq -r '.results | .[] | .name') || catch_error "curl => API failure"
     fi
     # check to see if a filter pattern was provided
@@ -653,6 +654,7 @@ query_source_images() {
     for i in ${REPO_LIST}
     do
       # get list of tags for image i
+      echo -e "${INFO} Grabbing tags for ${V1_REGISTRY}/${NAMESPACE}/${i}"
       IMAGE_TAGS=$(curl ${V1_OPTIONS} -sf ${V1_PROTO}://${AUTH_CREDS}@${V1_REGISTRY}/v1/repositories/${i}/tags | jq -r 'keys | .[]') || catch_error "curl => API failure"
 
       # retrieve a list of tags at the target repository

--- a/migrator.sh
+++ b/migrator.sh
@@ -377,8 +377,8 @@ query_tags_to_skip() {
   fi
 
   if [ "${AWS_ECR}" == "true" ]; then
-    echo -e "${INFO} Grabbing tags from AWS ECR"
-    TAGS=$(aws ecr list-images --repository-name ${NAMESPACE} --region ${AWS_REGION} | jq -cM '[.imageIds[].imageTag]')
+    echo -e "${INFO} Grabbing tags from AWS ECR for ${IMAGE}"
+    TAGS=$(aws ecr list-images --repository-name ${IMAGE} --region ${AWS_REGION} | jq -cM '[.imageIds[].imageTag]')
     echo ${TAGS}
     return 0
   fi

--- a/migrator.sh
+++ b/migrator.sh
@@ -624,9 +624,14 @@ query_source_images() {
       done
     done
   else
-    # get a list of all repos
-    FULL_REPO_LIST=$(curl ${V1_OPTIONS} -sf ${V1_PROTO}://${AUTH_CREDS}@${V1_REGISTRY}/v1/search?q= | jq -r '.results | .[] | .name') || catch_error "curl => API failure"
-
+    # Allow user to provide the full repo list
+    if [ -z "${V1_FULL_REPO_LIST}" ]
+    then
+      FULL_REPO_LIST=${V1_FULL_REPO_LIST}
+    else
+      # get a list of all repos
+      FULL_REPO_LIST=$(curl ${V1_OPTIONS} -sf ${V1_PROTO}://${AUTH_CREDS}@${V1_REGISTRY}/v1/search?q= | jq -r '.results | .[] | .name') || catch_error "curl => API failure"
+    fi
     # check to see if a filter pattern was provided
     if [ -z "${V1_REPO_FILTER}" ]
     then

--- a/migrator.sh
+++ b/migrator.sh
@@ -659,6 +659,7 @@ query_source_images() {
 
       # retrieve a list of tags at the target repository
       TAGS_AT_TARGET=$(query_tags_to_skip ${i})
+      echo -e "${INFO} Found the following existing tags at ${V2_REGISTRY}/${NAMESPACE}/${i}: ${TAGS_AT_TARGET}"
 
       # loop through tags to create list of full image names w/tags
       for j in ${IMAGE_TAGS}

--- a/migrator.sh
+++ b/migrator.sh
@@ -377,7 +377,6 @@ query_tags_to_skip() {
   fi
 
   if [ "${AWS_ECR}" == "true" ]; then
-    echo -e "${INFO} Grabbing tags from AWS ECR for ${IMAGE}"
     TAGS=$(aws ecr list-images --repository-name ${IMAGE} --region ${AWS_REGION} | jq -cM '[.imageIds[].imageTag]')
     echo ${TAGS}
     return 0
@@ -519,7 +518,7 @@ filter_tags() {
   FULL_IMAGE_NAME="${NAMESPACE}${NAMESPACE:+/}${i}:${j}"
 
   # only append this tag to the list if the tag wasn't pushed before
-  if [ $(json_array_contains ${TAGS_AT_TARGET} ${j}) = "true" ]; then
+  if [ "$(json_array_contains ${TAGS_AT_TARGET} ${j})" = "true" ]; then
     echo -e "${INFO} Skipping ${V1_REGISTRY}/${FULL_IMAGE_NAME}"
   else
     # no tag filter

--- a/migrator.sh
+++ b/migrator.sh
@@ -376,6 +376,13 @@ query_tags_to_skip() {
     return 0
   fi
 
+  if [ "${AWS_ECR}" == "true" ]; then
+    echo -e "${INFO} Grabbing tags from AWS ECR"
+    TAGS=$(aws ecr list-images --repository-name ${NAMESPACE} --region ${AWS_REGION} | jq -cM '[.imageIds[].imageTag]')
+    echo ${TAGS}
+    return 0
+  fi
+
   INNER_AUTH_TRIES=0
 
   AUTHORIZATION_HEADER="Authorization: Basic $(echo ${V2_USERNAME}:${V2_PASSWORD} | base64)"


### PR DESCRIPTION
This Pull request adds the ability to to provide a list of repos that a user would like to migrate. In our case this was necessary because the search functionality was disabled on our V1 repo and we did not have access to enable it. 

This PR also adds support to skip tags that have already been migrated to an ECR instance.

In addition there are some additions made for messaging which makes it easier for a user to know what will be migrated. There is also a minor change to a bash conditional to ensure that the comparison values will both be strings.